### PR TITLE
Update example in lower_case.js to conform to spec

### DIFF
--- a/src/case/lower_case.js
+++ b/src/case/lower_case.js
@@ -14,7 +14,7 @@ import coerceToString from 'helper/string/coerce_to_string';
  * // => 'green'
  *
  * v.lowerCase('BLUE');
- * // => 'BLUE'
+ * // => 'blue'
  */
 export default function lowerCase(subject) {
   const subjectString = coerceToString(subject, '');


### PR DESCRIPTION
Update the example in lower_case.js to reflect the correct output from the `lowerCase` method.

### Related issue

https://github.com/panzerdp/voca/issues/9

### Description

Documentation example shows:
```js
v.lowerCase('BLUE');
// => 'BLUE'
```

which should be
```js
v.lowerCase('BLUE');
// => 'blue'
```

Updated the example in the JSDoc string to reflect the correct output.

### Check List

- [x] All test passed
- [ ] Added test to ensure correctness