### PR TITLE
Fix typo

### DIFF
--- a/src/util/no_conflict.js
+++ b/src/util/no_conflict.js
@@ -13,7 +13,7 @@ const previousV = globalObject.v;
  * @return {Object} Returns Voca library instance.
  * @example
  * var voca = v.noConflict();
- * voca.isAlhpa('Hello');
+ * voca.isAlpha('Hello');
  * // => true
  */
 export default function noConflict() {


### PR DESCRIPTION
### Description

fix typo, modified `isAlhpa` to `isAlpha` in the doc description

### Check List

- [ ] All test passed
- [ ] Added test to ensure correctness