### PR TITLE
Fix 'trim' example result

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then in your application require the entire library:
 
 ```javascript
 var v = require('voca');
-v.trim(' Hello World! ');            // => 'Hello World'
+v.trim(' Hello World! ');            // => 'Hello World!'
 v.sprintf('%d red %s', 3, 'apples'); // => '3 red apples'
 ```
 


### PR DESCRIPTION
The return result of the 'trim' function example is missing the last exclamation point.