### PR TITLE
docs: Fix simple typo, caracters -> characters

### DIFF
--- a/src/case/swap_case.js
+++ b/src/case/swap_case.js
@@ -1,7 +1,7 @@
 import coerceToString from 'helper/string/coerce_to_string';
 
 /**
- * Converts the uppercase alpha caracters of `subject` to lowercase and lowercase
+ * Converts the uppercase alpha characters of `subject` to lowercase and lowercase
  * characters to uppercase.
  *
  * @function swapCase


### PR DESCRIPTION
There is a small typo in src/case/swap_case.js.

Should read `characters` rather than `caracters`.

