### PR TITLE
Fix doc typo in `const`

### DIFF
--- a/src/helper/number/const.js
+++ b/src/helper/number/const.js
@@ -1,5 +1,5 @@
 /**
- * Max save integer value
+ * Max safe integer value
  *
  * @ignore
  * @type {number}


### PR DESCRIPTION
### Related issue
None

### Description
The file at [src/helper/number/const.js](https://github.com/panzerdp/voca/blob/master/src/helper/number/const.js) had a typo in the JSdoc comment. It said "save integer" instead of "safe integer"

### Check List
- [x] All test passed
- [ ] Added test to ensure correctness